### PR TITLE
Add customers query

### DIFF
--- a/customers.sql
+++ b/customers.sql
@@ -1,0 +1,21 @@
+with customer_orders as (
+  select
+     customer_id
+     , count(*) as n_orders
+     , min(created_at) as first_order_at
+
+  from `analytics-engineers-club.coffee_shop.orders` 
+  group by 1
+)
+
+select 
+  customers.id as customer_id
+  , customers.name
+  , customers.email
+  , coalesce(customer_orders.n_orders, 0) as n_orders
+  , customer_orders.first_order_at
+from `analytics-engineers-club.coffee_shop.customers` as customers
+left join  customer_orders
+  on  customers.id = customer_orders.customer_id 
+
+limit 5


### PR DESCRIPTION
This query retrieves customer details along with their order history.

1️⃣ It first creates a temporary table (customer_orders) that calculates the total number of orders (n_orders) and the first order date (first_order_at) for each customer from the orders table.

2️⃣ Then, it joins the customers table with customer_orders using LEFT JOIN, ensuring all customers are included, even those without orders.

3️⃣ It retrieves customer details (ID, name, email) along with their order count and first order date. If a customer has no orders, n_orders is set to 0.

4️⃣ Finally, it limits the output to 5 rows to keep the result manageable.